### PR TITLE
Add two useful off-hand items (Saga of Terokk/Scepter of Interminable Focus)

### DIFF
--- a/src/js/items/items.js
+++ b/src/js/items/items.js
@@ -5013,6 +5013,14 @@ const items = {
       source: 'Heroic Slave Pens',
       phase: 1
     },
+    sagaOfTerokk: {
+        name: 'The Saga of Terokk',
+        intellect: 23,
+        spellPower: 28,
+        id: 29330,
+        source: 'Auchindoun (Quest)',
+        phase: 1
+    },
     masterSpellstone: {
       name: 'Master Spellstone',
       critRating: 20,
@@ -5029,6 +5037,15 @@ const items = {
       hitRating: 8,
       id: 23049,
       source: 'Naxxramas',
+      phase: 0
+    },
+    scepterOfInterminableFocus: {
+      name: "Scepter of Interminable Focus",
+      spellPower: 9,
+      critRating: 14,
+      hitRating: 8,
+      id: 22329,
+      source: 'Stratholme (Live)',
       phase: 0
     }
   },

--- a/src/js/items/items.js
+++ b/src/js/items/items.js
@@ -5014,12 +5014,12 @@ const items = {
       phase: 1
     },
     sagaOfTerokk: {
-        name: 'The Saga of Terokk',
-        intellect: 23,
-        spellPower: 28,
-        id: 29330,
-        source: 'Auchindoun (Quest)',
-        phase: 1
+      name: 'The Saga of Terokk',
+      intellect: 23,
+      spellPower: 28,
+      id: 29330,
+      source: 'Auchindoun (Quest)',
+      phase: 1
     },
     masterSpellstone: {
       name: 'Master Spellstone',


### PR DESCRIPTION
Hi, thanks for the super useful dashboard! I'm a theory crafter I love my new lock class, but I'm still leveling as a destro lock trying to find the most efficient playstyle.

This change adds two off-hand items that are easily accessible and can help with the initial gearing. I've tested it in VS22:
![offhand-test](https://user-images.githubusercontent.com/89152553/129987572-38b19658-5180-4006-b6ab-3335e4cdb84f.png)
