### PR TITLE
Fix a bug in sorting and avoid stack overflow for large arrays.

### DIFF
--- a/src/js/classes/simulation.js
+++ b/src/js/classes/simulation.js
@@ -626,7 +626,7 @@ class Simulation {
       console.log(this.timeTotal)
     }
 
-    dpsArray.sort()
+    dpsArray.sort((a, b) => a - b)
     this.simulationEnd({
       length: (performance.now() - startTime) / 1000,
       damageBreakdown: this.player.damageBreakdown,
@@ -635,8 +635,9 @@ class Simulation {
       combatlog: this.player.combatlog,
       iterations: this.iterations,
       medianDps: Math.round(median(dpsArray) * 100) / 100,
-      minDps: Math.round(Math.min(...dpsArray) * 100) / 100,
-      maxDps: Math.round(Math.max(...dpsArray) * 100) / 100,
+      // The array is already sorted, so we can access the first and last elements respectively.
+      minDps: Math.round(dpsArray[0] * 100) / 100,
+      maxDps: Math.round(dpsArray[dpsArray.length - 1] * 100) / 100,
       totalDamage: totalDamage,
       totalDuration: this.player.totalDuration,
       totalManaRegenerated: this.player.totalManaRegenerated,


### PR DESCRIPTION
Hi Kristopher, I found two bugs when playing with a large number of iterations:

1. sort() by default sorts alphabetically, so I've fixed so now the dps array is properly sorted (numerically)
2. for large number of iterations, e.g. 100,000, we are getting a stack overflow, so I simplified min/max logic by relying on the sorted array (after the fix)

I also think that your last commit was trying to work around the same bug in sort, so it can be reverted after this fix.

Secondly, I'm thinking of limiting the number iterations until it's statistically converged (within confidence intervals), because the dps array follows the normal distribution. Also min/max are not practically useful and it's better to use stddev (σ, e.g. -2σ, +2σ) as it better reflects the bell shape.

Lastly, the single iteration loop can be parallelized as it's currently the main bottleneck (although it may become moot once the confidence intervals are supported).
