### PR TITLE
A GCD bug fix + extra trinket

### DIFF
--- a/src/js/classes/player.js
+++ b/src/js/classes/player.js
@@ -541,7 +541,7 @@ class Player {
 
   cast (spell, predictedDamage = 0) {
     if (this.gcdRemaining > 0 && this.spells[spell].onGcd)
-      throw "Attempting to cast a spell (" + spell + ") on GCD with " + this.gcdRemaining + " cooldown remaining."
+      throw 'Attempting to cast a spell (' + spell + ') on GCD with ' + this.gcdRemaining + ' cooldown remaining.'
     this.spells[spell].startCast(predictedDamage)
   }
 

--- a/src/js/classes/player.js
+++ b/src/js/classes/player.js
@@ -539,7 +539,9 @@ class Player {
     this.importantAuraCounter = 0
   }
 
-  cast (spell, predictedDamage = 0) {
+  cast(spell, predictedDamage = 0) {
+    if (this.gcdRemaining > 0 && this.spells[spell].onGcd)
+      throw "Attempting to cast a spell (" + spell + ") on GCD with " + this.gcdRemaining + " cooldown remaining."
     this.spells[spell].startCast(predictedDamage)
   }
 

--- a/src/js/classes/player.js
+++ b/src/js/classes/player.js
@@ -539,7 +539,7 @@ class Player {
     this.importantAuraCounter = 0
   }
 
-  cast(spell, predictedDamage = 0) {
+  cast (spell, predictedDamage = 0) {
     if (this.gcdRemaining > 0 && this.spells[spell].onGcd)
       throw "Attempting to cast a spell (" + spell + ") on GCD with " + this.gcdRemaining + " cooldown remaining."
     this.spells[spell].startCast(predictedDamage)

--- a/src/js/classes/simulation.js
+++ b/src/js/classes/simulation.js
@@ -509,8 +509,9 @@ class Simulation {
                 }
               }
 
-              // If the sim is choosing the rotation for the player then check now which spell would be the best to cast
-              if (this.player.simChoosingRotation) {
+              // If the sim is choosing the rotation for the player then check now which spell would be the best to cast.
+              // We do another GCD check here, because we might have cast another spell (like curse) since the last check.
+              if (this.player.simChoosingRotation && this.player.gcdRemaining <= 0) {
                 // First index is the spell's varName and second index is the damage
                 let maxDamage = ['', 0]
                 for (const spell in predictedDamageOfSpells) {

--- a/src/js/items/items.js
+++ b/src/js/items/items.js
@@ -4534,17 +4534,6 @@ const items = {
       source: 'Terokkar Forest Quest',
       phase: 1
     },
-    starkillersBauble: {
-      name: "Starkiller's Bauble",
-      hitRating: 26,
-      onUseSpellPower: 125,
-      duration: 15,
-      cooldown: 90,
-      unique: true,
-      id: 30340,
-      source: 'Netherstorm Quest',
-      phase: 1
-    },
     theRestrainedEssenceOfSapphiron: {
       name: 'The Restrained Essence of Sapphiron',
       spellPower: 40,

--- a/src/js/items/items.js
+++ b/src/js/items/items.js
@@ -4532,6 +4532,17 @@ const items = {
       source: 'Terokkar Forest Quest',
       phase: 1
     },
+    starkillersBauble: {
+      name: "Starkiller's Bauble",
+      hitRating: 26,
+      onUseSpellPower: 125,
+      duration: 15,
+      cooldown: 90,
+      unique: true,
+      id: 30340,
+      source: 'Netherstorm Quest',
+      phase: 1
+    },
     theRestrainedEssenceOfSapphiron: {
       name: 'The Restrained Essence of Sapphiron',
       spellPower: 40,


### PR DESCRIPTION
Hi,

First of all, I've added a nice quest based trinket for those who are still before the hit cap, as it's superior to already present Terokarr Tablet of Vim.

Secondly, I came across a bug in _"Simulation chooses spells for me"_ mode, where casting player's curse would not respect the GCD, here is an example log showing the issue:

```
|0.0000| Fight length: 45 seconds
|0.0000| Curse of the Elements applied
|0.0000| Cast Curse of the Elements - Global cooldown: 1.5
|0.0000| Started casting Shadow Bolt - Cast time: 2.5 (0% haste at a base cast speed of 2.5). - Global cooldown: 1.5
|2.5001| Finished casting Shadow Bolt - Mana: 8634 -> 8214 - Mana Cost: 420 - Mana Cost Modifier: 100%
```
it can be easily reproduced by simply unchecking the selected curse and observing that DPS doesn't change (while it should be lower because of extra 1.5s waiting to cast the next spell).

While here, I've also added a check in `cast(...)` method to make sure this won't get undetected in future.